### PR TITLE
Add disable folder flag to avoid endless loop for OpenText initial sync state

### DIFF
--- a/Examples/Backend/Connectors/Connector-HelloWorld/Connector-HelloWorld.csproj
+++ b/Examples/Backend/Connectors/Connector-HelloWorld/Connector-HelloWorld.csproj
@@ -15,6 +15,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="5.6.8" />
+    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="5.6.9" />
   </ItemGroup>
 </Project>

--- a/Examples/Backend/Connectors/Connector-Picturepark/Connector-Picturepark.csproj
+++ b/Examples/Backend/Connectors/Connector-Picturepark/Connector-Picturepark.csproj
@@ -16,6 +16,6 @@
     </PackageReference>
     <PackageReference Include="Picturepark.SDK.V1" Version="11.6.23" />
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="5.6.8" />
+    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="5.6.9" />
   </ItemGroup>
 </Project>

--- a/Examples/Backend/Connectors/Connector-SharePoint/Connector-SharePoint.csproj
+++ b/Examples/Backend/Connectors/Connector-SharePoint/Connector-SharePoint.csproj
@@ -16,6 +16,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="5.6.8" />
+    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="5.6.9" />
   </ItemGroup>
 </Project>

--- a/Examples/Backend/DataAdapters/DataAdapter-HelloWorld/DataAdapter-HelloWorld.csproj
+++ b/Examples/Backend/DataAdapters/DataAdapter-HelloWorld/DataAdapter-HelloWorld.csproj
@@ -7,7 +7,7 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="5.6.8" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="5.6.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Connectors\Connector-HelloWorld\Connector-HelloWorld.csproj">

--- a/Examples/Backend/DataAdapters/DataAdapter-Picturepark/DataAdapter-Picturepark.csproj
+++ b/Examples/Backend/DataAdapters/DataAdapter-Picturepark/DataAdapter-Picturepark.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.2.656" />
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="5.6.8" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="5.6.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Connectors\Connector-Picturepark\Connector-Picturepark.csproj">

--- a/Examples/Backend/DataAdapters/DataAdapter-SharePoint/DataAdapter-SharePoint.csproj
+++ b/Examples/Backend/DataAdapters/DataAdapter-SharePoint/DataAdapter-SharePoint.csproj
@@ -7,7 +7,7 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="5.6.8" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="5.6.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Connectors\Connector-SharePoint\Connector-SharePoint.csproj">

--- a/Examples/Backend/DataAdapters/Portals-HelloWorld-TestDriver/Portals-Connector-SDK-TestDriver.HelloWorld.Test.csproj
+++ b/Examples/Backend/DataAdapters/Portals-HelloWorld-TestDriver/Portals-Connector-SDK-TestDriver.HelloWorld.Test.csproj
@@ -5,9 +5,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="5.6.8" />
-    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="5.6.8" />
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="5.6.8" />
+    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="5.6.9" />
+    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="5.6.9" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="5.6.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Examples/Backend/DataAdapters/Portals-Picturepark-TestDriver/Portals-Connector-SDK-TestDriver.Picturepark.Test.csproj
+++ b/Examples/Backend/DataAdapters/Portals-Picturepark-TestDriver/Portals-Connector-SDK-TestDriver.Picturepark.Test.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Picturepark.SDK.V1" Version="11.6.23" />
-    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="5.6.8" />
-    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="5.6.8" />
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="5.6.8" />
+    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="5.6.9" />
+    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="5.6.9" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="5.6.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Examples/Backend/DataAdapters/Portals-Sharepoint-TestDriver/Portals-Connector-SDK-TestDriver.Sharepoint.Test.csproj
+++ b/Examples/Backend/DataAdapters/Portals-Sharepoint-TestDriver/Portals-Connector-SDK-TestDriver.Sharepoint.Test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="4.25.0" />
-    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="5.6.8" />
-    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="5.6.8" />
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="5.6.8" />
+    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="5.6.9" />
+    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="5.6.9" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="5.6.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
## Change description

> Add disable folder flag to avoid endless loop for OpenText initial sync state

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code clean-up, etc.)

## Related issues

> https://trello.com/c/Dl0xAGmV/1299-opentext-via-cyangate-oneteg

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Network

- [X] Changes to network configurations have been reviewed
- [X] Any newly exposed public endpoints or data have gone through security review

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [Pre-cleared] "Ready for review" label attached and reviewers assigned
- [Pre-cleared] Changes have been reviewed by at least one other contributor
- [X] Pull request is linked to task tracker where applicable