### PR TITLE
Fix conversion warning for Picturepark

### DIFF
--- a/Examples/Backend/DataAdapters/DataAdapter-Picturepark/Assets/Common/PictureparkContentConverter.cs
+++ b/Examples/Backend/DataAdapters/DataAdapter-Picturepark/Assets/Common/PictureparkContentConverter.cs
@@ -971,6 +971,25 @@ namespace SmintIo.Portals.DataAdapter.Picturepark.Assets.Common
             return layerDataObjects.ToArray();
         }
 
+        protected override LocalizedStringsModel GetLocalizedStringsModelDataType(string propertyKey, JToken value, string semanticHint)
+        {
+            var dictionary = GetTypedValue<Dictionary<string, string>>(propertyKey, value, logWarning: false);
+
+            if (dictionary != null)
+            {
+                dictionary = FixDictionary(dictionary);
+
+                if (dictionary != null)
+                {
+                    return new LocalizedStringsModel(dictionary);
+                }
+
+                return null;
+            }
+
+            return base.GetLocalizedStringsModelDataType(propertyKey, value, semanticHint);
+        }
+
         protected override DateTimeOffset? GetDateTimeDataType(string propertyKey, JToken value, string semanticHint)
         {
             if (value.Type == JTokenType.Null)


### PR DESCRIPTION
## Change description

> Fix conversion warning for Picturepark

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code clean-up, etc.)

## Related issues

> see Sentry

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Network

- [X] Changes to network configurations have been reviewed
- [X] Any newly exposed public endpoints or data have gone through security review

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [Pre-cleared] "Ready for review" label attached and reviewers assigned
- [Pre-cleared] Changes have been reviewed by at least one other contributor
- [N/A] Pull request is linked to task tracker where applicable