### PR TITLE
Properly chunk Picturepark requests, make it a fast provider

### DIFF
--- a/Examples/Backend/DataAdapters/DataAdapter-Picturepark/Assets/Read/PictureparkAssetsRead.cs
+++ b/Examples/Backend/DataAdapters/DataAdapter-Picturepark/Assets/Read/PictureparkAssetsRead.cs
@@ -15,7 +15,6 @@ using SmintIo.Portals.SDK.Core.Http.Prefab.Models;
 using SmintIo.Portals.SDK.Core.Models.Metamodel;
 using SmintIo.Portals.SDK.Core.Models.Metamodel.Data;
 using SmintIo.Portals.SDK.Core.Models.Strings;
-using SmintIo.Portals.SDK.Core.Rest.Prefab.Exceptions;
 using PictureParkContentType = Picturepark.SDK.V1.Contract.ContentType;
 
 namespace SmintIo.Portals.DataAdapter.Picturepark.Assets
@@ -48,7 +47,7 @@ namespace SmintIo.Portals.DataAdapter.Picturepark.Assets
         {
             var featureSupport = new GetAssetsReadFeatureSupportResult
             {
-                IsFastGetAssetsSupported = false
+                IsFastGetAssetsSupported = true
             };
 
             return Task.FromResult(featureSupport);


### PR DESCRIPTION
## Change description

> Properly chunk Picturepark requests, make it a fast provider

## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)
- [ ] Maintenance (code clean-up, etc.)

## Related issues

> https://trello.com/c/oMc9IzZz/1634-make-sure-that-getassetsasync-in-different-clients-can-handle-a-very-large-number-of-incoming-ids-chunking-unify-chunking-approa

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Network

- [X] Changes to network configurations have been reviewed
- [X] Any newly exposed public endpoints or data have gone through security review

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [Exempt] "Ready for review" label attached and reviewers assigned
- [Exempt] Changes have been reviewed by at least one other contributor
- [X] Pull request is linked to task tracker where applicable