### PR TITLE
Show assets count for folders, allow to search for substrings in fragment search boxes, allow to enable sub folders search flag by default

### DIFF
--- a/Examples/Backend/Connectors/Connector-HelloWorld/Connector-HelloWorld.csproj
+++ b/Examples/Backend/Connectors/Connector-HelloWorld/Connector-HelloWorld.csproj
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="8.6.98" />
+    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="8.6.102" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\ConfigurationMessages.Designer.cs">

--- a/Examples/Backend/Connectors/Connector-Picturepark/Connector-Picturepark.csproj
+++ b/Examples/Backend/Connectors/Connector-Picturepark/Connector-Picturepark.csproj
@@ -30,7 +30,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Picturepark.SDK.V1" Version="11.14.35" />
-    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="8.6.98" />
+    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="8.6.102" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\ConfigurationMessages.Designer.cs">

--- a/Examples/Backend/Connectors/Connector-SharePoint/Connector-SharePoint.csproj
+++ b/Examples/Backend/Connectors/Connector-SharePoint/Connector-SharePoint.csproj
@@ -37,7 +37,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="8.6.98" />
+    <PackageReference Include="SmintIo.Portals.ConnectorSDK" Version="8.6.102" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\OneDriveConfigurationMessages.Designer.cs">

--- a/Examples/Backend/DataAdapters/DataAdapter-HelloWorld/DataAdapter-HelloWorld.csproj
+++ b/Examples/Backend/DataAdapters/DataAdapter-HelloWorld/DataAdapter-HelloWorld.csproj
@@ -16,7 +16,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="8.6.98" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="8.6.102" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Connectors\Connector-HelloWorld\Connector-HelloWorld.csproj">

--- a/Examples/Backend/DataAdapters/DataAdapter-Picturepark/DataAdapter-Picturepark.csproj
+++ b/Examples/Backend/DataAdapters/DataAdapter-Picturepark/DataAdapter-Picturepark.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.2.692" />
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="8.6.98" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="8.6.102" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Connectors\Connector-Picturepark\Connector-Picturepark.csproj">

--- a/Examples/Backend/DataAdapters/DataAdapter-SharePoint/Assets/Search/SharepointAssetsSearch.cs
+++ b/Examples/Backend/DataAdapters/DataAdapter-SharePoint/Assets/Search/SharepointAssetsSearch.cs
@@ -16,7 +16,7 @@ namespace SmintIo.Portals.DataAdapter.SharePoint.Assets
                 throw new NotImplementedException();
             }
 
-            return _smintIoIntegrationLayerProvider.GetFormItemDefinitionAllowedValuesAsync(_portalsContextModel, Context, parameters, _configuration.EnableFolderNavigation);
+            return _smintIoIntegrationLayerProvider.GetFormItemDefinitionAllowedValuesAsync(_portalsContextModel, Context, parameters, _configuration.EnableFolderNavigation, _configuration.SearchSubFoldersEnabledByDefault);
         }
 
         public override Task<SearchAssetsResult> SearchAssetsAsync(SearchAssetsParameters parameters)
@@ -26,7 +26,7 @@ namespace SmintIo.Portals.DataAdapter.SharePoint.Assets
                 throw new NotImplementedException();
             }
 
-            return _smintIoIntegrationLayerProvider.SearchAssetsAsync(_portalsContextModel, Context, parameters, _configuration.EnableFolderNavigation);
+            return _smintIoIntegrationLayerProvider.SearchAssetsAsync(_portalsContextModel, Context, parameters, _configuration.EnableFolderNavigation, _configuration.SearchSubFoldersEnabledByDefault);
         }
 
         public override Task<GetFullTextSearchProposalsResult> GetFullTextSearchProposalsAsync(GetFullTextSearchProposalsParameters parameters)

--- a/Examples/Backend/DataAdapters/DataAdapter-SharePoint/Assets/SharepointAssetsDataAdapterConfiguration.cs
+++ b/Examples/Backend/DataAdapters/DataAdapter-SharePoint/Assets/SharepointAssetsDataAdapterConfiguration.cs
@@ -71,6 +71,8 @@ namespace SmintIo.Portals.DataAdapter.SharePoint.Assets
 
         public bool EnableFolderNavigation { get; set; }
 
+        public bool SearchSubFoldersEnabledByDefault { get; set; }
+
         public bool SmintIoSearchIndexEnableNaturalLanguageSearch { get; set; }
 
         public bool SmintIoSearchIndexEnableReverseImageSearch { get; set; }

--- a/Examples/Backend/DataAdapters/DataAdapter-SharePoint/DataAdapter-SharePoint.csproj
+++ b/Examples/Backend/DataAdapters/DataAdapter-SharePoint/DataAdapter-SharePoint.csproj
@@ -21,7 +21,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="8.6.98" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK" Version="8.6.102" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Connectors\Connector-SharePoint\Connector-SharePoint.csproj">

--- a/Examples/Backend/DataAdapters/Portals-HelloWorld-TestDriver/Portals-Connector-SDK-TestDriver.HelloWorld.Test.csproj
+++ b/Examples/Backend/DataAdapters/Portals-HelloWorld-TestDriver/Portals-Connector-SDK-TestDriver.HelloWorld.Test.csproj
@@ -5,9 +5,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="8.6.98" />
-    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="8.6.98" />
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="8.6.98" />
+    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="8.6.102" />
+    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="8.6.102" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="8.6.102" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Examples/Backend/DataAdapters/Portals-Picturepark-TestDriver/Portals-Connector-SDK-TestDriver.Picturepark.Test.csproj
+++ b/Examples/Backend/DataAdapters/Portals-Picturepark-TestDriver/Portals-Connector-SDK-TestDriver.Picturepark.Test.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Picturepark.SDK.V1" Version="11.14.35" />
-    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="8.6.98" />
-    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="8.6.98" />
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="8.6.98" />
+    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="8.6.102" />
+    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="8.6.102" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="8.6.102" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Examples/Backend/DataAdapters/Portals-Sharepoint-TestDriver/Portals-Connector-SDK-TestDriver.Sharepoint.Test.csproj
+++ b/Examples/Backend/DataAdapters/Portals-Sharepoint-TestDriver/Portals-Connector-SDK-TestDriver.Sharepoint.Test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="4.25.0" />
-    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="8.6.98" />
-    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="8.6.98" />
-    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="8.6.98" />
+    <PackageReference Include="SmintIo.Portals.Connector.Test" Version="8.6.102" />
+    <PackageReference Include="SmintIo.Portals.DataAdapter.Test" Version="8.6.102" />
+    <PackageReference Include="SmintIo.Portals.DataAdapterSDK.TestDriver" Version="8.6.102" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">


### PR DESCRIPTION
## Change description

> Show assets count for folders
> Allow to search for substrings in fragment search boxes
> Allow to enable sub folders search flag by default

## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)
- [ ] Maintenance (code clean-up, etc.)

## Related issues

> https://app.frontapp.com/open/cnv_1boknvbq?key=SVubJMe7rZp8z0cQNV77Q7jnNFa81K-N
> https://app.frontapp.com/open/cnv_1bokmryu?key=HMY6H95qvOqWwJH6sXB7cY5LvENTeKho
> https://smintio.slack.com/archives/C07LLST15PF/p1775586556626709

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Network

- [X] Changes to network configurations have been reviewed
- [X] Any newly exposed public endpoints or data have gone through security review

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [Exempt] "Ready for review" label attached and reviewers assigned
- [Exempt] Changes have been reviewed by at least one other contributor
- [X] Pull request is linked to task tracker where applicable