### PR TITLE
Add content permission UUIDs to Picturepark content converter

### DIFF
--- a/Examples/Backend/DataAdapters/DataAdapter-Picturepark/Assets/Common/PictureparkContentConverter.cs
+++ b/Examples/Backend/DataAdapters/DataAdapter-Picturepark/Assets/Common/PictureparkContentConverter.cs
@@ -115,6 +115,14 @@ namespace SmintIo.Portals.DataAdapter.Picturepark.Assets.Common
                 }
             }
 
+            if (contentDetail.ContentPermissionSetIds != null && contentDetail.ContentPermissionSetIds.Any())
+            {
+                asset.ExternalSecurity = new ExternalSecurityDataObject()
+                {
+                    ExternalSecurityGroupIds = contentDetail.ContentPermissionSetIds?.ToArray()
+                };
+            }
+
             if (string.IsNullOrEmpty(asset.Version))
             {
                 asset.Version = "0";
@@ -336,6 +344,14 @@ namespace SmintIo.Portals.DataAdapter.Picturepark.Assets.Common
             }
 
             asset.PermissionUuids = permissionUuids.ToArray();
+
+            if (contentDetail.ContentPermissionSetIds != null && contentDetail.ContentPermissionSetIds.Any())
+            {
+                asset.ExternalSecurity = new ExternalSecurityDataObject()
+                {
+                    ExternalSecurityGroupIds = contentDetail.ContentPermissionSetIds?.ToArray()
+                };
+            }
 
             if (string.IsNullOrEmpty(asset.Version))
             {


### PR DESCRIPTION
## Change description

> Add content permission UUIDs to Picturepark content converter

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code clean-up, etc.)

## Related issues

> N/A

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Network

- [X] Changes to network configurations have been reviewed
- [X] Any newly exposed public endpoints or data have gone through security review

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [Exempt] "Ready for review" label attached and reviewers assigned
- [Exempt] Changes have been reviewed by at least one other contributor
- [N/A] Pull request is linked to task tracker where applicable